### PR TITLE
fix params.pp so that it works with strict_mode

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -6,6 +6,8 @@ class archive::params {
       $owner = '0'
       $group = '0'
       $mode  = '0640'
+      $seven_zip_name = undef
+      $seven_zip_provider = undef
     }
     'Windows': {
       $path               = $::staging_windir


### PR DESCRIPTION
Without this change, strict_mode will make puppet say:

`Error: Could not retrieve catalog from remote server: Error 400 on SERVER: Undefined variable "archive::params::seven_zip_name"; Undefined variable "seven_zip_name" at /etc/puppet/environments/production/modules/archive/manifests/init.pp:14 on node puppet`