### PR TITLE
add proxy support, add new params to readme documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,8 @@ class { 'archive':
 * `group`: extract command group (using this option will configure the archive file permisison to 0644 so the user can read the file).
 * `cleanup`: whether archive file will be removed after extraction (true|false). (default: true)
 * `creates`: if file/directory exists, will not download/extract archive.
+* `proxy_server`: specify a proxy server, with port number if needed. ie: https://example.com:8080.
+* `proxy_type`: proxy server type (none|http|https|ftp)
 
 #### Example:
 ```puppet

--- a/lib/puppet/provider/archive/curl.rb
+++ b/lib/puppet/provider/archive/curl.rb
@@ -27,6 +27,10 @@ Puppet::Type.type(:archive).provide(:curl, :parent => :ruby) do
       fail 'password specfied without username.'
     end
 
+    if resource[:proxy_server]
+      @curl_params << '--proxy' << "#{resource[:proxy_server]}"
+    end
+
     #
     # Manage cookie parameter
     #

--- a/lib/puppet/provider/archive/faraday.rb
+++ b/lib/puppet/provider/archive/faraday.rb
@@ -13,7 +13,7 @@ Puppet::Type.type(:archive).provide(:faraday, :parent => :ruby) do
     temppath = tempfile.path
     tempfile.close!
 
-    PuppetX::Bodeco::Util.download(resource[:source], temppath, :username => resource[:username], :password => resource[:password], :cookie => resource[:cookie])
+    PuppetX::Bodeco::Util.download(resource[:source], temppath, :username => resource[:username], :password => resource[:password], :cookie => resource[:cookie], :proxy_server => resource[:proxy_server], :proxy_type => resource[:proxy_type])
 
     # conditionally verify checksum:
     if resource[:checksum_verify] == :true && resource[:checksum_type] != :none

--- a/lib/puppet/provider/archive/wget.rb
+++ b/lib/puppet/provider/archive/wget.rb
@@ -16,6 +16,7 @@ Puppet::Type.type(:archive).provide(:wget, :parent => :ruby) do
     append_if(resource[:username], '--user=%s')
     append_if(resource[:password], '--password=%s')
     append_if(resource[:cookie], '--header="Cookie: "%s"')
+    append_if(resource[:proxy_server], "--#{resource[:proxy_type]}_proxy=#{resource[:proxy_server]}")
 
     wget(@wget_params)
 

--- a/lib/puppet/type/archive.rb
+++ b/lib/puppet/type/archive.rb
@@ -150,6 +150,15 @@ Puppet::Type.newtype(:archive) do
     desc 'extract command group (using this option will configure the archive file permisison to 0644 so the user can read the file).'
   end
 
+  newparam(:proxy_type) do
+    desc 'proxy type (none|ftp|http|https)'
+    newvalues(:none, :ftp, :http, :https)
+  end
+
+  newparam(:proxy_server) do
+    desc 'proxy address to use when accessing source'
+  end
+
   autorequire(:package) do
     'faraday_middleware'
   end
@@ -161,5 +170,10 @@ Puppet::Type.newtype(:archive) do
   validate do
     filepath = Pathname.new(self[:path])
     self[:filename] = filepath.basename.to_s
+    if self[:proxy_server]
+      self[:proxy_type] ||= URI(self[:proxy_server]).scheme.to_sym
+    else
+      self[:proxy_type] = :none
+    end
   end
 end

--- a/lib/puppet_x/bodeco/util.rb
+++ b/lib/puppet_x/bodeco/util.rb
@@ -21,6 +21,7 @@ module PuppetX
         username = options[:username]
         password = options[:password]
         cookie = options[:cookie]
+        proxy_server = options[:proxy_server]
         # Try one last time since PUP-1879 isn't always available:
         unless defined? ::Faraday
           Gem.clear_paths unless defined? ::Bundler
@@ -31,7 +32,10 @@ module PuppetX
           ENV['SSL_CERT_FILE'] = File.expand_path(File.join(__FILE__, '..', '..', '..', '..', 'files', 'cacert.pem'))
         end
 
-        @connection = ::Faraday.new(url) do |conn|
+        @connection = ::Faraday.new(
+          url,
+          :proxy => proxy_server
+          ) do |conn|
           conn.basic_auth(username, password) if username && password
 
           conn.response :raise_error # This let's us know if the transfer failed.
@@ -63,10 +67,15 @@ module PuppetX
 
     class FTP
       require 'net/ftp'
+
       def initialize(url, options)
         uri = URI(url)
         username = options[:username]
         password = options[:password]
+        proxy_server = options[:proxy_server]
+        proxy_type = options[:proxy_type]
+
+        ENV["#{proxy_type}_proxy"] = proxy_server
 
         @ftp = Net::FTP.new
         @ftp.connect(uri.host, uri.port)

--- a/spec/unit/puppet/provider/archive/curl_spec.rb
+++ b/spec/unit/puppet/provider/archive/curl_spec.rb
@@ -82,5 +82,20 @@ RSpec.describe curl_provider do
         provider.download(name)
       end
     end
+
+    context 'using proxy' do
+      let(:resource_properties) do
+        {
+          :name => name,
+          :source => 'http://home.lan/example.zip',
+          :proxy_server => 'https://home.lan:8080'
+        }
+      end
+
+      it 'calls curl with proxy' do
+        expect(provider).to receive(:curl).with(default_options << '--proxy' << 'https://home.lan:8080')
+        provider.download(name)
+      end
+    end
   end
 end

--- a/spec/unit/puppet/provider/archive/wget_spec.rb
+++ b/spec/unit/puppet/provider/archive/wget_spec.rb
@@ -78,5 +78,20 @@ RSpec.describe wget_provider do
         provider.download(name)
       end
     end
+
+    context 'proxy specified' do
+      let(:resource_properties) do
+        {
+          :name => name,
+          :source => 'http://home.lan/example.zip',
+          :proxy_server => 'https://home.lan:8080',
+        }
+      end
+
+      it 'calls wget with default options and header containing cookie' do
+        expect(provider).to receive(:wget).with(default_options << '--https_proxy=https://home.lan:8080')
+        provider.download(name)
+      end
+    end
   end
 end


### PR DESCRIPTION
Added proxy support to types and providers, as well as unit tests. I spun up a squid vagrant instance and a base instance, ran the tests/archive.pp with the new params set, and all ran well. Added the params to the readme documentation as well.