### PR TITLE
Make directory before transferring file

### DIFF
--- a/lib/puppet/provider/archive/curl.rb
+++ b/lib/puppet/provider/archive/curl.rb
@@ -45,6 +45,7 @@ Puppet::Type.type(:archive).provide(:curl, :parent => :ruby) do
       fail(Puppet::Error, 'Download file checksum mismatch') unless archive.checksum(resource[:checksum_type]) == checksum
     end
 
+    FileUtils.mkdir_p(File.dirname(archive_filepath))
     FileUtils.mv(temppath, archive_filepath)
   end
 end

--- a/lib/puppet/provider/archive/curl.rb
+++ b/lib/puppet/provider/archive/curl.rb
@@ -2,15 +2,11 @@ Puppet::Type.type(:archive).provide(:curl, :parent => :ruby) do
   commands :curl => 'curl'
   defaultfor :feature => :posix
 
-  def download(archive_filepath)
-    tempfile = Tempfile.new(tempfile_name)
-    temppath = tempfile.path
-    tempfile.close!
-
+  def download(filepath)
     @curl_params = [
       resource[:source],
       '-o',
-      temppath,
+      filepath,
       '-L',
       '--max-redirs',
       5
@@ -37,15 +33,5 @@ Puppet::Type.type(:archive).provide(:curl, :parent => :ruby) do
     @curl_params << '--cookie' << "#{resource[:cookie]}" if resource[:cookie]
 
     curl(@curl_params)
-
-    # conditionally verify checksum:
-    if resource[:checksum_verify] == :true && resource[:checksum_type] != :none
-
-      archive = PuppetX::Bodeco::Archive.new(temppath)
-      fail(Puppet::Error, 'Download file checksum mismatch') unless archive.checksum(resource[:checksum_type]) == checksum
-    end
-
-    FileUtils.mkdir_p(File.dirname(archive_filepath))
-    FileUtils.mv(temppath, archive_filepath)
   end
 end

--- a/lib/puppet/provider/archive/faraday.rb
+++ b/lib/puppet/provider/archive/faraday.rb
@@ -22,6 +22,7 @@ Puppet::Type.type(:archive).provide(:faraday, :parent => :ruby) do
       fail(Puppet::Error, 'Download file checksum mismatch') unless archive.checksum(resource[:checksum_type]) == checksum
     end
 
+    FileUtils.mkdir_p(File.dirname(archive_filepath))
     FileUtils.mv(temppath, archive_filepath)
   end
 end

--- a/lib/puppet/provider/archive/faraday.rb
+++ b/lib/puppet/provider/archive/faraday.rb
@@ -8,21 +8,7 @@ rescue LoadError
 end
 
 Puppet::Type.type(:archive).provide(:faraday, :parent => :ruby) do
-  def download(archive_filepath)
-    tempfile = Tempfile.new(tempfile_name)
-    temppath = tempfile.path
-    tempfile.close!
-
-    PuppetX::Bodeco::Util.download(resource[:source], temppath, :username => resource[:username], :password => resource[:password], :cookie => resource[:cookie], :proxy_server => resource[:proxy_server], :proxy_type => resource[:proxy_type])
-
-    # conditionally verify checksum:
-    if resource[:checksum_verify] == :true && resource[:checksum_type] != :none
-
-      archive = PuppetX::Bodeco::Archive.new(temppath)
-      fail(Puppet::Error, 'Download file checksum mismatch') unless archive.checksum(resource[:checksum_type]) == checksum
-    end
-
-    FileUtils.mkdir_p(File.dirname(archive_filepath))
-    FileUtils.mv(temppath, archive_filepath)
+  def download(filepath)
+    PuppetX::Bodeco::Util.download(resource[:source], filepath, :username => resource[:username], :password => resource[:password], :cookie => resource[:cookie], :proxy_server => resource[:proxy_server], :proxy_type => resource[:proxy_type])
   end
 end

--- a/lib/puppet/provider/archive/wget.rb
+++ b/lib/puppet/provider/archive/wget.rb
@@ -1,15 +1,11 @@
 Puppet::Type.type(:archive).provide(:wget, :parent => :ruby) do
   commands :wget => 'wget'
 
-  def download(archive_filepath)
-    tempfile = Tempfile.new(tempfile_name)
-    temppath = tempfile.path
-    tempfile.close!
-
+  def download(filepath)
     @wget_params = [
       resource[:source],
       '-O',
-      temppath,
+      filepath,
       '--max-redirect=5',
     ]
 
@@ -19,16 +15,6 @@ Puppet::Type.type(:archive).provide(:wget, :parent => :ruby) do
     append_if(resource[:proxy_server], "--#{resource[:proxy_type]}_proxy=#{resource[:proxy_server]}")
 
     wget(@wget_params)
-
-    # conditionally verify checksum:
-    if resource[:checksum_verify] == :true && resource[:checksum_type] != :none
-
-      archive = PuppetX::Bodeco::Archive.new(temppath)
-      fail(Puppet::Error, 'Download file checksum mismatch') unless archive.checksum(resource[:checksum_type]) == checksum
-    end
-
-    FileUtils.mkdir_p(File.dirname(archive_filepath))
-    FileUtils.mv(temppath, archive_filepath)
   end
 
   private

--- a/lib/puppet/provider/archive/wget.rb
+++ b/lib/puppet/provider/archive/wget.rb
@@ -27,6 +27,7 @@ Puppet::Type.type(:archive).provide(:wget, :parent => :ruby) do
       fail(Puppet::Error, 'Download file checksum mismatch') unless archive.checksum(resource[:checksum_type]) == checksum
     end
 
+    FileUtils.mkdir_p(File.dirname(archive_filepath))
     FileUtils.mv(temppath, archive_filepath)
   end
 


### PR DESCRIPTION
* ensure the directory exists.
* remove duplicate code in multiple providers.