### PR TITLE
Do not assume aio-agent if Puppet version >= 4

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -19,9 +19,7 @@ class archive::params {
     }
   }
 
-  if versioncmp($::puppetversion, '4.0.0') >= 0 {
-    $gem_provider = 'puppet_gem'
-  } elsif $::puppetversion =~ /Puppet Enterprise/ and $::osfamily != 'Windows' {
+  if $::puppetversion =~ /Puppet Enterprise/ and $::osfamily != 'Windows' {
     $gem_provider = 'pe_gem'
   } elsif $::aio_agent_version {
     $gem_provider = 'puppet_gem'


### PR DESCRIPTION
Fixes #103 

As far as I know the All-in-one agent is only available for Puppet 4, and having Puppet 4 installed doesn't necessarily mean it came with the All-in-one agent (OS like Fedora provide up-to-date rpm packages for Puppet 4)